### PR TITLE
Fix banner size for mobile

### DIFF
--- a/assets/scss/_footer.scss
+++ b/assets/scss/_footer.scss
@@ -11,7 +11,8 @@
     padding-bottom: 1em;
     webring-banner {
       width: 50%;
-      margin: 0 auto;      
+      margin: 0 auto;     
+      min-width: 360px;
     }
   }
 }


### PR DESCRIPTION
### Prerequisites

Put an `x` into the box(es) that apply:

- [x] This pull request fixes a bug.

### Description

Added a min width to the banner

### Issues Resolved

On mobile the banner gets squashed with the width at 50%
<img width="381" alt="Screenshot 2021-01-29 at 22 14 40" src="https://user-images.githubusercontent.com/415593/106332798-646a7880-627f-11eb-8787-a5630984c59a.png">

### Checklist

Put an `x` into the box(es) that apply:

#### General

- [x] Describe what changes are being made
- [x] Explain why and how the changes were necessary and implemented respectively

#### Resources

- [ ] If you have changed any SCSS code, run `make release` to regenerate all CSS files (<==== TE LO FAI TE)

#### Contributors

- [ ] Add yourself to `CONTRIBUTORS.md` if you aren't on it already (<==== IT'S OK, NO SWEAT)
